### PR TITLE
Tag-ancilary-resources

### DIFF
--- a/test/fixtures/aws/bigip.tf
+++ b/test/fixtures/aws/bigip.tf
@@ -1,5 +1,5 @@
 module "bigip" {
-  source                     = "git::git@github.com:f5devcentral/terraform-aws-bigip-module.git?ref=v0.9.7"
+  source                     = "git::git@github.com:F5Networks/terraform-aws-bigip-module.git?ref=v1.0.0"
   count                      = 1
   prefix                     = format("%s-3nic", var.prefix)
   f5_ami_search_name         = "F5 BIGIP-15.* PAYG-Best 200Mbps*"
@@ -12,4 +12,5 @@ module "bigip" {
   #external_alias_ip_count   = 2
   internal_subnet_ids        = [{ "subnet_id" = module.vpc.private_subnets[count.index], "public_ip" = false, "private_ip_primary" = "" }]
   internal_securitygroup_ids = [module.bigip_sg.this_security_group_id, module.bigip_mgmt_sg.this_security_group_id]
+  tags                       = merge(local.tags,{})
 }

--- a/test/fixtures/aws/main.tf
+++ b/test/fixtures/aws/main.tf
@@ -17,10 +17,4 @@ resource "random_string" "password" {
   override_special = "_%@"
 }
 
-locals {
-    tags = merge(var.tags,{
-        Terraform   = "true"
-        Environment = var.environment
-      }
-    )
-}
+

--- a/test/fixtures/aws/main.tf
+++ b/test/fixtures/aws/main.tf
@@ -16,3 +16,11 @@ resource "random_string" "password" {
   special          = true
   override_special = "_%@"
 }
+
+locals {
+    tags = merge(var.tags,{
+        Terraform   = "true"
+        Environment = var.environment
+      }
+    )
+}

--- a/test/fixtures/aws/network.tf
+++ b/test/fixtures/aws/network.tf
@@ -12,12 +12,14 @@ module "vpc" {
   public_subnets = [for num in range(length(var.azs)) :
     cidrsubnet(var.cidr, 8, num + var.external_subnet_offset)
   ]
+  public_subnet_tags = merge(local.tags,{})
 
   # vpc private subnet used for internal 
   private_subnets = [
     for num in range(length(var.azs)) :
     cidrsubnet(var.cidr, 8, num + var.internal_subnet_offset)
   ]
+  private_subnet_tags = merge(local.tags,{})
 
   enable_nat_gateway = true
 
@@ -29,12 +31,12 @@ module "vpc" {
   create_database_subnet_group           = true
   create_database_subnet_route_table     = true
   create_database_internet_gateway_route = true
+  database_subnet_tags = merge(local.tags,{})
 
-  tags = {
-    Name        = format("%s-vpc-%s", var.prefix, random_id.id.hex)
-    Terraform   = "true"
-    Environment = "dev"
-  }
+  tags = merge(local.tags,{
+      Name = format("%s-vpc-%s", var.prefix, random_id.id.hex)
+    }
+  )
 }
 
 module "bigip_sg" {
@@ -58,6 +60,10 @@ module "bigip_sg" {
   # Allow ec2 instances outbound Internet connectivity
   egress_cidr_blocks = ["0.0.0.0/0"]
   egress_rules       = ["all-all"]
+  tags = merge(local.tags,{
+    Name = format("%s-bigipsg-%s", var.prefix, random_id.id.hex)
+    }
+  )
 }
 
 #
@@ -83,4 +89,8 @@ module "bigip_mgmt_sg" {
   # Allow ec2 instances outbound Internet connectivity
   egress_cidr_blocks = ["0.0.0.0/0"]
   egress_rules       = ["all-all"]
+  tags = merge(local.tags,{
+    Name = format("%s-bigipmgmtsg-%s", var.prefix, random_id.id.hex)
+    }
+  )
 }

--- a/test/fixtures/aws/outputs.tf
+++ b/test/fixtures/aws/outputs.tf
@@ -10,7 +10,7 @@ output "bigip_password" {
 }
 
 output bigip_address {
-  value = module.bigip[0].mgmtPublicIP[0]
+  value = module.bigip[0].mgmtPublicIP
 }
 
 output bigip_port {

--- a/test/fixtures/aws/postbuildconfig.tf
+++ b/test/fixtures/aws/postbuildconfig.tf
@@ -2,7 +2,7 @@ module "postbuild-config-do" {
   source           = "../../..//do"
   bigip_user       = "admin"
   bigip_password   = random_string.password.result
-  bigip_address    = module.bigip[0].mgmtPublicIP[0]
+  bigip_address    = module.bigip[0].mgmtPublicIP
   bigip_do_payload = templatefile("${path.module}/../../assets/do.json",
   { 
     nameserver              = var.nameserver
@@ -25,7 +25,7 @@ module "postbuild-config-sh" {
   source           = "../../..//sh"
   bigip_user       = "admin"
   bigip_password   = random_string.password.result
-  bigip_address    = module.bigip[0].mgmtPublicIP[0]
+  bigip_address    = module.bigip[0].mgmtPublicIP
   bigip_shell_payload = templatefile("${path.module}/../../assets/postbuild.sh",{ maxclients = 20, mergeinterval = 10 })
   depends_on = [
     module.postbuild-config-do

--- a/test/fixtures/aws/variables.tf
+++ b/test/fixtures/aws/variables.tf
@@ -1,3 +1,11 @@
+locals {
+    tags = merge(var.tags,{
+        Terraform   = "true"
+        Environment = var.environment
+      }
+    )
+}
+
 variable "prefix" {
   default = "kitchen-terraform"
 }

--- a/test/fixtures/aws/variables.tf
+++ b/test/fixtures/aws/variables.tf
@@ -1,6 +1,15 @@
 variable "prefix" {
   default = "kitchen-terraform"
 }
+
+variable "environment" {
+  type    = string
+  default = "test"
+}
+variable "tags" {
+  type    = map(string)
+  default = {}
+}
 ## Europe Regions need oder Jumphost and BigIP Instance Typs1
 ## Uncomment needed region below
 

--- a/test/fixtures/azure/bigip.tf
+++ b/test/fixtures/azure/bigip.tf
@@ -11,5 +11,6 @@ module bigip {
   internal_subnet_ids        = [{ "subnet_id" = data.azurerm_subnet.internal.id, "public_ip" = false, "private_ip_primary" = "" }]
   internal_securitygroup_ids = [module.internal-network-security-group.network_security_group_id]
   availabilityZones          = [var.azs[0]]
+  tags                       = merge(local.tags,{})
 }
 

--- a/test/fixtures/azure/main.tf
+++ b/test/fixtures/azure/main.tf
@@ -70,11 +70,3 @@ resource "random_id" "id" {
     
     byte_length = 2
 }
-
-locals {
-    tags = merge(var.tags,{
-        Terraform   = "true"
-        Environment = var.environment
-      }
-    )
-}

--- a/test/fixtures/azure/main.tf
+++ b/test/fixtures/azure/main.tf
@@ -70,3 +70,11 @@ resource "random_id" "id" {
     
     byte_length = 2
 }
+
+locals {
+    tags = merge(var.tags,{
+        Terraform   = "true"
+        Environment = var.environment
+      }
+    )
+}

--- a/test/fixtures/azure/network.tf
+++ b/test/fixtures/azure/network.tf
@@ -11,10 +11,10 @@ module "network" {
   subnet_prefixes     = [cidrsubnet(var.cidr, 8, 1), cidrsubnet(var.cidr, 8, 2), cidrsubnet(var.cidr, 8, 3)]
   subnet_names        = ["mgmt-subnet", "external-subnet", "internal-subnet"]
 
-  tags = {
-    environment = "test"
-    costcenter  = "it"
-  }
+  tags = merge(local.tags,{
+    Name = format("%s-bigipsg-%s", var.prefix, random_id.id.hex)
+    }
+  )
 }
 
 data "azurerm_subnet" "mgmt" {
@@ -46,10 +46,10 @@ module mgmt-network-security-group {
   source              = "Azure/network-security-group/azurerm"
   resource_group_name = azurerm_resource_group.main.name
   security_group_name = format("%s-mgmt-nsg-%s", var.prefix, random_id.id.hex)
-  tags = {
-    environment = "test"
-    costcenter  = "test"
-  }
+  tags = merge(local.tags,{
+    Name = format("%s-mgmt-nsg-%s", var.prefix, random_id.id.hex)
+    }
+  )
 }
 
 #
@@ -59,10 +59,10 @@ module external-network-security-group {
   source              = "Azure/network-security-group/azurerm"
   resource_group_name = azurerm_resource_group.main.name
   security_group_name = format("%s-external-nsg-%s", var.prefix, random_id.id.hex)
-  tags = {
-    environment = "dev"
-    costcenter  = "terraform"
-  }
+  tags = merge(local.tags,{
+    Name = format("%s-external-nsg-%s", var.prefix, random_id.id.hex)
+    }
+  )
 }
 
 resource "azurerm_network_security_rule" "mgmt_allow_https" {
@@ -127,8 +127,8 @@ module "internal-network-security-group" {
   resource_group_name   = azurerm_resource_group.main.name
   security_group_name   = format("%s-internal-nsg-%s", var.prefix, random_id.id.hex)
   source_address_prefix = ["10.0.3.0/24"]
-  tags = {
-    environment = "dev"
-    costcenter  = "terraform"
-  }
+  tags = merge(local.tags,{
+    Name = format("%s-internal-nsg-%s", var.prefix, random_id.id.hex)
+    }
+  )
 }

--- a/test/fixtures/azure/variables.tf
+++ b/test/fixtures/azure/variables.tf
@@ -28,6 +28,11 @@ variable "prefix" {
     default = "ktchntst"
 }
 
+variable "tags" {
+  type    = map(string)
+  default = {}
+}
+
 variable "application_count" {
     default = 1
 }
@@ -86,3 +91,4 @@ variable onboard_log {
 variable "nameserver" {
   default = "8.8.8.8"
 }
+

--- a/test/fixtures/azure/variables.tf
+++ b/test/fixtures/azure/variables.tf
@@ -1,3 +1,11 @@
+locals {
+    tags = merge(var.tags,{
+        Terraform   = "true"
+        Environment = var.environment
+      }
+    )
+}
+
 # must select a region that supports availability zones
 # https://docs.microsoft.com/en-us/azure/availability-zones/az-overview
 variable "region" {


### PR DESCRIPTION
apply tags defined in var.tags to all created resources. the GCP BIG-IP module doesn't support tagging, so isn't included.